### PR TITLE
Revert "Update github status badge link"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI Status](https://github.com/AY2526S1-CS2103-F12-2/tp/actions/workflows/gradle.yml/badge.svg)](https://github.com/se-edu/addressbook-level3/actions)
+[![CI Status](https://github.com/se-edu/addressbook-level3/workflows/Java%20CI/badge.svg)](https://github.com/se-edu/addressbook-level3/actions)
 
 ![Ui](docs/images/Ui.png)
 


### PR DESCRIPTION
Reverts AY2526S1-CS2103-F12-2/tp#33 - badge URL was half correct