### PR TITLE
151 edit command confusing message

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -177,7 +177,7 @@ public class EditCommand extends Command {
 
         updatedTags.addAll(tagsToAdd);
         updatedTags.removeAll(tagsToRemove);
-        invalidRemovals.removeAll(updatedTags);
+        invalidRemovals.removeAll(baseTags);
         invalidRemovals.removeAll(tagsToAdd);
 
         return new TagUpdateResult(updatedTags, invalidRemovals);


### PR DESCRIPTION
closes #151 

Resolved the issue by adding removing the newly added tags from `invalidremovals` as well.

<img width="598" height="361" alt="image" src="https://github.com/user-attachments/assets/732db70c-67ad-4243-a31c-4068ffa47bf9" />
