### PR TITLE
Fix bug where backspace was disabled

### DIFF
--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -174,12 +174,14 @@ public class MainWindow extends UiPart<Stage> {
         KeyCode keyCode = event.getCode();
         if (keyCode.equals(ENTER_SCROLL_MODE)) {
             handleEnterScrollMode();
+            event.consume();
         } else if (keyCode.equals(SCROLL_MODE_NEXT) || keyCode.equals(SCROLL_MODE_NEXT_ALT)) {
             handleNavigateNext();
+            event.consume();
         } else if (keyCode.equals(SCROLL_MODE_PREVIOUS) || keyCode.equals(SCROLL_MODE_PREVIOUS_ALT)) {
             handleNavigatePrevious();
+            event.consume();
         }
-        event.consume();
     }
 
     /**


### PR DESCRIPTION
I've made an oopsie. Accidentally put an `event.consume()` that consumed all keypress events resulting in backspace being broken. This pull request fixes that oopsie.