### PR TITLE
Update withPinPriority method in ModelManager

### DIFF
--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -238,7 +238,12 @@ public class ModelManager implements Model {
             if (baseComparator != null) {
                 return baseComparator.compare(p1, p2);
             }
-            return 0;
+
+
+            List<Person> originalList = addressBook.getPersonList();
+            int index1 = originalList.indexOf(p1);
+            int index2 = originalList.indexOf(p2);
+            return Integer.compare(index1, index2);
         };
     }
 }


### PR DESCRIPTION
resolves #160
resolves #140 
resolves #171

# Summary of Changes
## TLDR
Fix `withPinPriority` method to return a proper deterministic order and not `0` when `baseComparator` is `null`

## Issue
Unstable sorting behavior in `ModelManager`’s `SortedList` caused by the `withPinPriority` method comparator returning 0 when no base comparator was provided. i.e. `baseComparator==null`.

## Why it happened
By the comparator returning `0`, it signifies that the two element are equal in sorting order. However, because of this, SortedList can't maintain a deterministic order.

As a result this caused newly set elements to potentially jump positions because when an element in our `ObservableList<Person> internalList` is replaced via `.set(personToEdit, newPerson`, it will trigger a change event for the `SortedList` . This is handled inside `SortedList` using the `addRemove()` method which 
1. removes the old element from `sorted[]` Element array, and the `perm[]` int array.
2. inserts the new element using `insertToMapping()` which performs a binary search on **`sorted[]` according to the comparator**

Hence, since the comprator returned 0, the binary search can't determine a unique position, hence causing it to place the element arbitraily among equal elements.
- This is why is is placed in the middle of the list (i.e. after Charlotte whatever her name was).
- And because of the order of the SortedList was updated, the newly updated "Alex Yeoh" is pushed to the middle, 
- And because we are iterating through the sortedlist, when it jumps to the next person. it will jump to "Charlotte ..." who is now located in the second index, thus bypassing "Bernice ...". which is why "Bernice..." tags remain unchanged.

This is also the reason why there were issues when using `resetSortOrder` when apply the default list command after using `applyNameSort` or `applyRecentSort` because the comparator caused it to lose the deterministic ordering.

## Fix
Instead of returning `0`, it will rely on the original indexing order of the addressbook (i,e, internalList). This ensures that all remaining unpinned contacts will have a stable ordering guaranteed because due the deterministic property of the indexs.

## Extra notes
Thanks to @Harjun751 who helped with the debugging process
Three lines of code updated. My brain now wants to explode lol