### PR TITLE
Fix CommandHistory #184

### DIFF
--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -177,10 +177,8 @@ public class MainWindow extends UiPart<Stage> {
             event.consume();
         } else if (keyCode.equals(SCROLL_MODE_NEXT) || keyCode.equals(SCROLL_MODE_NEXT_ALT)) {
             handleNavigateNext();
-            event.consume();
         } else if (keyCode.equals(SCROLL_MODE_PREVIOUS) || keyCode.equals(SCROLL_MODE_PREVIOUS_ALT)) {
             handleNavigatePrevious();
-            event.consume();
         }
     }
 

--- a/src/test/java/seedu/address/ui/MainWindowTest.java
+++ b/src/test/java/seedu/address/ui/MainWindowTest.java
@@ -36,6 +36,7 @@ public class MainWindowTest {
     public Path temporaryFolder;
 
     private final Model model = new ModelManager();
+    private final CommandHistory chm = new CommandHistory();
     private MainWindow mainWindow;
 
     @Start
@@ -55,7 +56,7 @@ public class MainWindowTest {
         mainWindow = new MainWindow(stage, new LogicManager(model, storage, new StateManager()));
         mainWindow.show();
         mainWindow.fillInnerParts();
-        mainWindow.createCommandBox(new Autocompletor(), new CommandHistory());
+        mainWindow.createCommandBox(new Autocompletor(), chm);
     }
 
     @Test
@@ -172,6 +173,21 @@ public class MainWindowTest {
         robot.push(MainWindow.SCROLL_MODE_PREVIOUS_ALT);
 
         assertEquals(firstPerson, mainWindow.getPersonListPanel().getSelectedPerson());
+    }
+
+    // Integration test to check if command history plays well in main window
+    @Test
+    public void insertMode_fillsOldCommandHistory_onPreviousHistoryInput(FxRobot robot) {
+        // Arrange - select second person by pressing SCROLL_NEXT_ALT twice
+        TextField t = robot.lookup("#commandTextField").queryAs(TextField.class);
+        String oldCommand = "this was typed in previously";
+        chm.clearHistory();
+        chm.addCommandToHistory(oldCommand);
+
+        robot.clickOn("#commandTextField");
+        robot.push(CommandBox.GO_PREVIOUS_COMMAND);
+
+        assertEquals(oldCommand, t.getText());
     }
 
 }


### PR DESCRIPTION
Resolves #184 

CommandHistory function is not functional.

Update MainWindow to not consume arrow key events
to allow CommandBox to receive those events to handle.

Add integration test to prevent such a break from occurring again.