### PR TITLE
Update DarkTheme.css for the hyperlink colors

### DIFF
--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -140,13 +140,13 @@
     -fx-border-width: 0;
 }
 
-.cell_small_hyperlink:hover {
-    -fx-text-fill: #4077b3; /* light blue on hover */
+.cell_small_hyperlink:visited {
+    -fx-text-fill: #c74ac7; /* set to purple for visited links */
     -fx-underline: false;
 }
 
-.cell_small_hyperlink:visited {
-    -fx-text-fill: #29006b; /* set to purple for visited links */
+.cell_small_hyperlink:hover {
+    -fx-text-fill: #4077b3; /* light blue on hover */
     -fx-underline: false;
 }
 


### PR DESCRIPTION
resolves #165 

basically just updated the css to ensure better visibility.

I also updated it such that hovering on a visited hyperlink will still highlight the visited link.
- for this just reordered the css

this is how it looks now:
<img width="230" height="150" alt="Screenshot 2025-10-29 110532" src="https://github.com/user-attachments/assets/0d055d26-806a-426e-8eba-fbb86a22a731" />
