### PR TITLE
Fix program failure when data folder missing #178

### DIFF
--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -150,8 +150,10 @@ public class LogicManager implements Logic {
         try {
             saveOperation.apply(storage);
         } catch (AccessDeniedException e) {
+            logger.info("Error occurred while saving to file: " + e.getMessage());
             throw new CommandException(String.format(FILE_OPS_PERMISSION_ERROR_FORMAT, e.getMessage()), e);
         } catch (IOException ioe) {
+            logger.info("Error occurred while saving to file: " + ioe.getMessage());
             throw new CommandException(String.format(FILE_OPS_ERROR_FORMAT, ioe.getMessage()), ioe);
         }
     }

--- a/src/main/java/seedu/address/storage/NewlineDelimitedCommandHistoryStorage.java
+++ b/src/main/java/seedu/address/storage/NewlineDelimitedCommandHistoryStorage.java
@@ -1,5 +1,7 @@
 package seedu.address.storage;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
@@ -31,9 +33,7 @@ public class NewlineDelimitedCommandHistoryStorage implements CommandHistoryStor
 
     @Override
     public Optional<CommandHistory> readCommandHistory() throws DataLoadingException {
-        if (filePath == null) {
-            throw new NullPointerException();
-        }
+        requireNonNull(filePath);
         if (!FileUtil.isFileExists(filePath)) {
             return Optional.empty();
         }
@@ -63,13 +63,27 @@ public class NewlineDelimitedCommandHistoryStorage implements CommandHistoryStor
 
     @Override
     public void saveCommandHistory(ReadOnlyCommandHistory history) throws IOException {
+        requireNonNull(history);
+        requireNonNull(filePath);
+
+        String data = convertHistoryToNewlineDelimitedString(history);
+
+        FileUtil.createIfMissing(filePath);
+        FileUtil.writeToFile(filePath, data);
+    }
+
+    private String convertHistoryToNewlineDelimitedString(ReadOnlyCommandHistory history) {
+        requireNonNull(history);
+
         StringBuilder sb = new StringBuilder();
         List<String> historyList = history.getHistory();
 
+        // Reverse-iterate through the list to order data from
+        // the oldest command (top) -> the newest command (bottom)
         for (int i = historyList.size() - 1; i >= 0; i--) {
             sb.append(historyList.get(i)).append("\n");
         }
 
-        FileUtil.writeToFile(filePath, sb.toString());
+        return sb.toString();
     }
 }

--- a/src/main/java/seedu/address/storage/StorageManager.java
+++ b/src/main/java/seedu/address/storage/StorageManager.java
@@ -95,6 +95,7 @@ public class StorageManager implements Storage {
 
     @Override
     public void saveCommandHistory(ReadOnlyCommandHistory commandHistory) throws IOException {
+        logger.fine("Attempting to write to data file: " + getCommandHistoryFilePath());
         commandHistoryStorage.saveCommandHistory(commandHistory);
     }
 


### PR DESCRIPTION
Closes #178 

Program fails to execute commands when data folder is missing.

Add checks to create folder if not present when writing to desired command history path. Add extra variable checks when saving. Log exceptions in saving in LogicManager.