### PR TITLE
270 273 281 288 launch bugs

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -727,15 +727,17 @@ testers are expected to do more *exploratory* testing.
 ### Launching Communication Mode
 
 1. Launch First Person's Email.
-   1. Prerequisites: The first person in the displayed list has an email
+   1. Prerequisites: The first person in the displayed list has a Telegram Handle
 
-   2. Test: `launch 1 -e` <br>
+   2. Test: `launch 1 -l` <br>
       Expected Result Display:
         ```
-        Launched EMAIL successfully.
+        Launched TELEGRAM successfully.
       Note: You can only launch Telegram links from the browser if you have the Telegram application installed on your device.
         ```
-      Expected Result: Email Draft to the selected email should launch and Result display show the success message above as well as a caveat about launching telegram
+      Expected Result (regardless of Internet Access): 
+      1. Verify that a browser opens with the URL formatted `https://t.me/HANDLE` whereby handle should be the specified contact's telegram handle, 
+      2. & Result display show the success message above.
 
 2. Launch Second Person's without the specified communication mode.
    1. Prerequisites: The second person in the displayed list does **NOT** have a telegram handle
@@ -745,7 +747,8 @@ testers are expected to do more *exploratory* testing.
        ```
       Person Name This person does not have a Telegram handle.
        ```
-      Expected Result: Result display show the message of the contact's name followed by the error message above
+      Expected Result: 
+      1. Result display show the message of the contact's name followed by the error message above
 
 3. Launch Third Person's GitHub.
     1. Prerequisites: The third person in the displayed list has a GitHub username and user has access to pointing device that can interact with the GUI.
@@ -756,7 +759,9 @@ testers are expected to do more *exploratory* testing.
        Launched GitHub successfully.
        Note: You can only launch Telegram links from the browser if you have the Telegram application installed on your device.
        ```
-       Expected Result: GitHub page of the selected username should launch and Result display show the success message above as well as a caveat about launching telegram
+       Expected Result (regardless of Internet Access):
+       1. Verify that a browser opens with the URL formatted `https://github.com/USERNAME` whereby username should be the specified contact's GitHub username,
+       2. & Result display shows the success message above.
 
 4. Launching the User Guide.
    1. Test: Press the `F1` key <br>
@@ -765,7 +770,9 @@ testers are expected to do more *exploratory* testing.
        Launched USERGUIDE successfully.
        Note: You can only launch Telegram links from the browser if you have the Telegram application installed on your device.
        ```
-      Expected Result: User Guide to Devbooks should launch and Result display show the success message above as well as a caveat about launching telegram
+      Expected Result: 
+      1. Verify that a browser opens with the specific URL `https://ay2526s1-cs2103-f12-2.github.io/tp/UserGuide.html`,
+      2. and Result display show the success message above as well as a caveat about launching telegram
 
 ### Renaming the Tags for Multiple Users
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -273,7 +273,9 @@ Press `k` to select the entry above the current entry.
 
 ### Launching external communication modes : `launch`
 
-Launches an external application to communicate with the specified person via the specified mode.
+Launches a browser to communicate with the specified person via the specified mode.
+
+Scope: launching the browser with the correct link specified below.
 
 Format: `launch INDEX [-l (Telegram) | -g (GitHub)]`
 
@@ -290,9 +292,10 @@ Format: `launch INDEX [-l (Telegram) | -g (GitHub)]`
 * User's interaction with the launched application is outside the scope of this feature.
 * User's can also launch external application through the GUI by left-clicking the Telegram or GitHub links of a person in the person card.
 
+
 Examples:
-* `launch 3 -l` launches Telegram web browser to open a chat with the 3rd person's Telegram handle in the displayed person list.
-* `launch 1 -g` launches web browser to the GitHub profile of the 1st person in the displayed person list.
+* `launch 3 -l` launches browser with the formatted link `https://t.me/HANDLE`, with `HANDLE` as the  Telegram handle of the 3rd person's in the displayed person list (given they have a Telegram Handle).
+* `launch 1 -g` launches browser with the formatted link `https://github.com/USERNAME`, with the `USERNAME` as the GitHub username of the 1st person in the displayed person list (given they have a GitHub username).
 
 **Important Notes:**
 * The launch command has only been tested on the following operating systems.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -275,28 +275,24 @@ Press `k` to select the entry above the current entry.
 
 Launches an external application to communicate with the specified person via the specified mode.
 
-Format: `launch INDEX [-e (Email)] [-l (Telegram)] [-g (GitHub)]`
+Format: `launch INDEX [-l (Telegram) | -g (GitHub)]`
 
 * The index refers to the index number shown in the displayed person list. The index **must be a positive integer** 1, 2, 3, …​
 * Use the flag to specify the communication mode:
-    * `-e` launches the default email application to compose an email to the person's email address.
-        * Depending on the user's system settings, the email may be composed in an email client or web browser.
-    * `-l` launches Telegram web browser that links to opening a chat with the person's Telegram handle.
-        * To open the chat through web browser, the user is required to have Telegram application installed on their device.
-        * Checking existence of Telegram user is outside the scope of this feature and is handled by Telegram application.
-    * `-g` launches web browser that links to the person's GitHub profile.
+    * `-l` launches browser with the formatted link `https://t.me/HANDLE`, whereby handle should be the specified contact's Telegram handle,
+        * Do note, to open the chat through web browser, the user is required to have Telegram application installed on their device. (i.e. send button does not allow redirecting Telegram web)
+          * However, the ability to check with is also beyond the scope of this feature.
+        * Additionally, checking existence of Telegram user is outside the scope of this feature and is handled by Telegram application.
+    * `-g` launches browser with the formatted link `https://github.com/USERNAME`, whereby username should be the specified contact's GitHub username,
         * Checking existence of GitHub user is outside the scope of this feature and is handled by GitHub.
 * User must specify **exactly one flag**.
 * If the person does not have the specified communication mode, an error message is shown.
 * User's interaction with the launched application is outside the scope of this feature.
-* User's can launch external application through the GUI by left-clicking the email, telegram or github icon of a person in the person card.
+* User's can also launch external application through the GUI by left-clicking the Telegram or GitHub links of a person in the person card.
 
 Examples:
-* `launch 2 -e` launches the default email application to compose an email to the 2nd person in the displayed person list.
 * `launch 3 -l` launches Telegram web browser to open a chat with the 3rd person's Telegram handle in the displayed person list.
 * `launch 1 -g` launches web browser to the GitHub profile of the 1st person in the displayed person list.
-* Launching through CLI ![result for Launching CLI](gifs/LaunchCli.gif)
-* Launching through GUI ![result for Launching GUI](gifs/LaunchGui.gif)
 
 **Important Notes:**
 * The launch command has only been tested on the following operating systems.
@@ -434,7 +430,7 @@ Action | Format, Examples
 **Find** | `find n\KEYWORD [MORE_KEYWORDS]` or `find t\KEYWORD [MORE_KEYWORDS]`<br> e.g., `find n\James Jake`, `find t\friend`
 **List** | `list [-a (alphabetical)] [-r (recent)]`<br> e.g., `list -a`
 **Help** | `help COMMAND`
-**Launch** | `launch INDEX [-e (Email)] [-l (Telegram)] [-g (GitHub)]`<br> e.g., `launch 2 -e`
+**Launch** | `launch INDEX [-l (Telegram)] [-g (GitHub)]`<br> e.g., `launch 2 -l`
 **Tag** | Rename: `tag -r t\TAG r\TAG` <br> `tag -r t\CS1101 r\CS2103` <br><br> Delete: `tag -d t\TAG…` <br> `tag -d t\CS1101`
 **Pin** | `pin INDEX` <br> e.g., `pin 3`
 **Unpin** | `unpin INDEX` <br> e.g., `unpin 1`

--- a/src/main/java/seedu/address/logic/commands/LaunchCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LaunchCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.FLAG_EMAIL_LAUNCH;
 import static seedu.address.logic.parser.CliSyntax.FLAG_GITHUB_LAUNCH;
 import static seedu.address.logic.parser.CliSyntax.FLAG_TELEGRAM_LAUNCH;
 
@@ -31,7 +30,6 @@ public class LaunchCommand extends Command {
     private static final String MESSAGE_DESCRIPTION =
             "Launches the specified application for a person in the address book";
     private static final String MESSAGE_PARAMETERS = "Parameters: INDEX (must be a positive integer)"
-            + "[" + FLAG_EMAIL_LAUNCH + " (email) | "
             + FLAG_TELEGRAM_LAUNCH + " (telegram) | "
             + FLAG_GITHUB_LAUNCH + " (github)]"
             + "\n\nNotes:\n"
@@ -39,8 +37,7 @@ public class LaunchCommand extends Command {
             + "  - Exactly one application flag must be specified.\n"
             + "  - Email launch application/browser must be configured on your system.\n"
             + "  - Telegram and GitHub links will be launched in your default web browser.\n";
-    private static final String MESSAGE_EXAMPLE = "Example: " + COMMAND_WORD + " 1 " + FLAG_EMAIL_LAUNCH
-            + " (Launches the email application/browser for the person at index 1 in the address book.)";
+    private static final String MESSAGE_EXAMPLE = "Example: " + COMMAND_WORD + " 1 " + FLAG_TELEGRAM_LAUNCH;
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": " + MESSAGE_DESCRIPTION + "\n\n"
             + MESSAGE_PARAMETERS + "\n" + MESSAGE_EXAMPLE;
     public static final String MESSAGE_UNRECOGNIZED_FLAG = "Unrecognized application flag provided.\n" + MESSAGE_USAGE;
@@ -95,10 +92,6 @@ public class LaunchCommand extends Command {
         requireNonNull(type);
 
         switch (type) {
-        case EMAIL: {
-            isFieldEmpty(person.getEmail().isEmpty(), person.getName().fullName, MESSAGE_MISSING_EMAIL);
-            return ApplicationLinkLauncher.launchEmail(person.getEmail().value);
-        }
         case TELEGRAM: {
             isFieldEmpty(person.getTelegram().isEmpty(), person.getName().fullName, MESSAGE_MISSING_TELEGRAM);
             return ApplicationLinkLauncher.launchTelegram(person.getTelegram().value);

--- a/src/main/java/seedu/address/logic/commands/LaunchCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LaunchCommand.java
@@ -23,7 +23,6 @@ public class LaunchCommand extends Command {
 
     public static final String COMMAND_WORD = "launch";
 
-    static final String MESSAGE_MISSING_EMAIL = "%s This person does not have an email address.";
     static final String MESSAGE_MISSING_TELEGRAM = "%s This person does not have a Telegram handle.";
     static final String MESSAGE_MISSING_GITHUB = "%s This person does not have a GitHub profile.";
 

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -20,7 +20,6 @@ public class CliSyntax {
     public static final Prefix FLAG_RECENT_ORDER = new Prefix("-r");
 
     /* Flag definitions (for Launch Command) */
-    public static final Prefix FLAG_EMAIL_LAUNCH = new Prefix("-e");
     public static final Prefix FLAG_TELEGRAM_LAUNCH = new Prefix("-l");
     public static final Prefix FLAG_GITHUB_LAUNCH = new Prefix("-g");
 

--- a/src/main/java/seedu/address/logic/parser/LaunchCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/LaunchCommandParser.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.FLAG_EMAIL_LAUNCH;
 import static seedu.address.logic.parser.CliSyntax.FLAG_GITHUB_LAUNCH;
 import static seedu.address.logic.parser.CliSyntax.FLAG_TELEGRAM_LAUNCH;
 
@@ -18,8 +17,8 @@ public class LaunchCommandParser implements Parser<LaunchCommand> {
     public static final String MESSAGE_USAGE = LaunchCommand.COMMAND_WORD + ": Launches the specified application "
             + "for the person identified by the index number used in the displayed person list.\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + "[" + FLAG_EMAIL_LAUNCH + " | " + FLAG_TELEGRAM_LAUNCH + " | " + FLAG_GITHUB_LAUNCH + "]\n"
-            + "Example: " + LaunchCommand.COMMAND_WORD + " 1 " + FLAG_EMAIL_LAUNCH;
+            + FLAG_TELEGRAM_LAUNCH + " | " + FLAG_GITHUB_LAUNCH + "]\n"
+            + "Example: " + LaunchCommand.COMMAND_WORD + " 1 " + FLAG_GITHUB_LAUNCH;
 
     /**
      * Parses the given {@code String} of arguments in the context of the LaunchCommand
@@ -32,7 +31,7 @@ public class LaunchCommandParser implements Parser<LaunchCommand> {
         // Implementation for parsing launch command arguments
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(
-                        args, FLAG_EMAIL_LAUNCH, FLAG_TELEGRAM_LAUNCH, FLAG_GITHUB_LAUNCH
+                        args, FLAG_TELEGRAM_LAUNCH, FLAG_GITHUB_LAUNCH
                 );
 
         Index index;
@@ -43,15 +42,11 @@ public class LaunchCommandParser implements Parser<LaunchCommand> {
         }
 
         // Ensures that exactly one flag is provided
-        boolean emailFlag = argMultimap.getValue(FLAG_EMAIL_LAUNCH).isPresent();
         boolean telegramFlag = argMultimap.getValue(FLAG_TELEGRAM_LAUNCH).isPresent();
         boolean githubFlag = argMultimap.getValue(FLAG_GITHUB_LAUNCH).isPresent();
-        boolean isOnlyEmail = emailFlag && !telegramFlag && !githubFlag;
-        boolean isOnlyTelegram = !emailFlag && telegramFlag && !githubFlag;
-        boolean isOnlyGithub = !emailFlag && !telegramFlag && githubFlag;
-        if (isOnlyEmail) {
-            return new LaunchCommand(index, ApplicationType.EMAIL);
-        } else if (isOnlyTelegram) {
+        boolean isOnlyTelegram = telegramFlag && !githubFlag;
+        boolean isOnlyGithub = !telegramFlag && githubFlag;
+        if (isOnlyTelegram) {
             return new LaunchCommand(index, ApplicationType.TELEGRAM);
         } else if (isOnlyGithub) {
             return new LaunchCommand(index, ApplicationType.GITHUB);

--- a/src/main/java/seedu/address/logic/parser/LaunchCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/LaunchCommandParser.java
@@ -17,7 +17,7 @@ public class LaunchCommandParser implements Parser<LaunchCommand> {
     public static final String MESSAGE_USAGE = LaunchCommand.COMMAND_WORD + ": Launches the specified application "
             + "for the person identified by the index number used in the displayed person list.\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + FLAG_TELEGRAM_LAUNCH + " | " + FLAG_GITHUB_LAUNCH + "]\n"
+            + "[" + FLAG_TELEGRAM_LAUNCH + " | " + FLAG_GITHUB_LAUNCH + "]\n"
             + "Example: " + LaunchCommand.COMMAND_WORD + " 1 " + FLAG_GITHUB_LAUNCH;
 
     /**

--- a/src/main/java/seedu/address/logic/util/ApplicationLinkLauncher.java
+++ b/src/main/java/seedu/address/logic/util/ApplicationLinkLauncher.java
@@ -10,7 +10,7 @@ import java.util.logging.Logger;
 import seedu.address.commons.core.LogsCenter;
 
 /**
- * Utility class to launch external application links such as email, Telegram, and GitHub.
+ * Utility class to launch external application links such as User Guide, Telegram and GitHub.
  */
 public class ApplicationLinkLauncher {
 

--- a/src/main/java/seedu/address/logic/util/ApplicationLinkLauncher.java
+++ b/src/main/java/seedu/address/logic/util/ApplicationLinkLauncher.java
@@ -23,7 +23,6 @@ public class ApplicationLinkLauncher {
     private static final String MESSAGE_DESKTOP_API_LAUNCH_FAIL = "DesktopAPI failed to open link: %s";
 
     private static final String LAUNCH_NO_PREFIX = "";
-    private static final String LAUNCH_EMAIL_PREFIX = "mailto:";
     private static final String LAUNCH_TELEGRAM_PREFIX = "https://t.me/";
     private static final String LAUNCH_GITHUB_PREFIX = "http://github.com/";
 
@@ -34,16 +33,6 @@ public class ApplicationLinkLauncher {
     private static ApplicationLinkResult launchApp(String prefix, String value, ApplicationType type) {
         requireNonNull(value);
         return launchApplicationLink(prefix + value, type);
-    }
-
-    /**
-     * Launches the email application with the specified email address.
-     *
-     * @param email The email address to launch.
-     * @return The result of the launch attempt.
-     */
-    public static ApplicationLinkResult launchEmail(String email) {
-        return launchApp(LAUNCH_EMAIL_PREFIX, email, ApplicationType.EMAIL);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/util/ApplicationType.java
+++ b/src/main/java/seedu/address/logic/util/ApplicationType.java
@@ -4,7 +4,6 @@ package seedu.address.logic.util;
  * Enum representing different application types.
  */
 public enum ApplicationType {
-    EMAIL,
     TELEGRAM,
     GITHUB,
     USERGUIDE,

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -45,7 +45,7 @@ public class PersonCard extends UiPart<Region> {
     @FXML
     private Label phone;
     @FXML
-    private Hyperlink email;
+    private Label email;
     @FXML
     private Hyperlink telegram;
     @FXML
@@ -158,16 +158,6 @@ public class PersonCard extends UiPart<Region> {
         TextFlow flow = new TextFlow(mainText, preferredText);
         label.setGraphic(flow);
         label.setText(""); // clear plain text to prevent duplication
-    }
-
-    /**
-     * Launches the email application with the person's email address.
-     * FeedbackConsumer will set resultDisplay based on success/failure of launch.
-     */
-    @FXML
-    public void launchEmail() {
-        ApplicationLinkResult result = ApplicationLinkLauncher.launchEmail(person.getEmail().value);
-        feedbackConsumer.accept(result.getMessage());
     }
 
     /**

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -34,7 +34,7 @@
         </HBox>
         <FlowPane fx:id="tags" />
         <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
-        <Hyperlink fx:id="email" styleClass="cell_small_hyperlink" onAction="#launchEmail" text="\$email" />
+        <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
         <Hyperlink fx:id="telegram" styleClass="cell_small_hyperlink" onAction="#launchTelegram" text="\$telegram" />
         <Hyperlink fx:id="github" styleClass="cell_small_hyperlink" onAction="#launchGithub" text="\$telegram" />
       </VBox>

--- a/src/test/java/seedu/address/logic/commands/LaunchCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/LaunchCommandTest.java
@@ -32,28 +32,6 @@ public class LaunchCommandTest {
     private final Model model = new ModelManager();
 
     /**
-     * Tests that executing a LaunchCommand for Email on a person with an email address
-     * results in a successful launch.
-     */
-    @Test
-    public void excute_launchCommand_emailsuccess() {
-        Person person = new PersonBuilder().withEmail(VALID_EMAIL_AMY).build();
-        model.addPerson(person);
-        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(), new CommandHistory());
-
-        // Mock the static method ApplicationLinkLauncher.launchEmail
-        try (MockedStatic<ApplicationLinkLauncher> mocked = mockStatic(ApplicationLinkLauncher.class)) {
-            mocked.when(() -> ApplicationLinkLauncher.launchEmail(VALID_EMAIL_AMY))
-                    .thenReturn(new ApplicationLinkResult(true,
-                            String.format(ApplicationLinkLauncher.MESSAGE_SUCCESS, ApplicationType.EMAIL)));
-
-            LaunchCommand command = new LaunchCommand(INDEX_FIRST_PERSON, ApplicationType.EMAIL);
-            String expectedMessage = String.format(ApplicationLinkLauncher.MESSAGE_SUCCESS, ApplicationType.EMAIL);
-            assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        }
-    }
-
-    /**
      * Tests that executing a LaunchCommand for Telegram on a person with a Telegram handle
      * results in a successful launch.
      */
@@ -104,26 +82,12 @@ public class LaunchCommandTest {
         Person person = new PersonBuilder().build();
         model.addPerson(person);
 
-        LaunchCommand command = new LaunchCommand(INDEX_SECOND_PERSON, ApplicationType.EMAIL);
+        LaunchCommand command = new LaunchCommand(INDEX_SECOND_PERSON, ApplicationType.TELEGRAM);
         assertCommandFailure(
                 command,
                 model,
                 Messages.getMessageInvalidPersonDisplayedIndex(INDEX_SECOND_PERSON.getOneBased(),
                         model.getSortedAndFilteredPersonList().size()));
-    }
-
-    /**
-     * Tests that executing a LaunchCommand for Email on a person without an email address
-     * results in a CommandException being thrown.
-     */
-    @Test
-    public void execute_missingEmail_throwsCommandException() {
-        Person person = new PersonBuilder().build();
-        model.addPerson(person);
-
-        LaunchCommand command = new LaunchCommand(INDEX_FIRST_PERSON, ApplicationType.EMAIL);
-        assertCommandFailure(command, model,
-                String.format(MESSAGE_MISSING_EMAIL, person.getName().fullName));
     }
 
     /**
@@ -170,33 +134,33 @@ public class LaunchCommandTest {
     /* The following test cases checks if the equals methods works properly */
     @Test
     public void equals_sameObject_returnsTrue() {
-        LaunchCommand launchCommand = new LaunchCommand(INDEX_FIRST_PERSON, ApplicationType.EMAIL);
+        LaunchCommand launchCommand = new LaunchCommand(INDEX_FIRST_PERSON, ApplicationType.TELEGRAM);
         assert launchCommand.equals(launchCommand);
     }
 
     @Test
     public void equals_notInstanceOfLaunchCommand_returnsFalse() {
-        LaunchCommand launchCommand = new LaunchCommand(INDEX_FIRST_PERSON, ApplicationType.EMAIL);
+        LaunchCommand launchCommand = new LaunchCommand(INDEX_FIRST_PERSON, ApplicationType.TELEGRAM);
         assert !launchCommand.equals("Some String");
     }
 
     @Test
     public void equals_sameValues_returnsTrue() {
-        LaunchCommand launchCommand1 = new LaunchCommand(INDEX_FIRST_PERSON, ApplicationType.EMAIL);
-        LaunchCommand launchCommand2 = new LaunchCommand(INDEX_FIRST_PERSON, ApplicationType.EMAIL);
+        LaunchCommand launchCommand1 = new LaunchCommand(INDEX_FIRST_PERSON, ApplicationType.TELEGRAM);
+        LaunchCommand launchCommand2 = new LaunchCommand(INDEX_FIRST_PERSON, ApplicationType.TELEGRAM);
         assert launchCommand1.equals(launchCommand2);
     }
 
     @Test
     public void equals_differentIndex_returnsFalse() {
-        LaunchCommand launchCommand1 = new LaunchCommand(INDEX_FIRST_PERSON, ApplicationType.EMAIL);
-        LaunchCommand launchCommand2 = new LaunchCommand(INDEX_SECOND_PERSON, ApplicationType.EMAIL);
+        LaunchCommand launchCommand1 = new LaunchCommand(INDEX_FIRST_PERSON, ApplicationType.TELEGRAM);
+        LaunchCommand launchCommand2 = new LaunchCommand(INDEX_SECOND_PERSON, ApplicationType.TELEGRAM);
         assert !launchCommand1.equals(launchCommand2);
     }
 
     @Test
     public void equals_differentApplicationType_returnsFalse() {
-        LaunchCommand launchCommand1 = new LaunchCommand(INDEX_FIRST_PERSON, ApplicationType.EMAIL);
+        LaunchCommand launchCommand1 = new LaunchCommand(INDEX_FIRST_PERSON, ApplicationType.GITHUB);
         LaunchCommand launchCommand2 = new LaunchCommand(INDEX_FIRST_PERSON, ApplicationType.TELEGRAM);
         assert !launchCommand1.equals(launchCommand2);
     }

--- a/src/test/java/seedu/address/logic/commands/LaunchCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/LaunchCommandTest.java
@@ -6,7 +6,6 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_GITHUB_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TELEGRAM_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.logic.commands.LaunchCommand.MESSAGE_MISSING_EMAIL;
 import static seedu.address.logic.commands.LaunchCommand.MESSAGE_MISSING_GITHUB;
 import static seedu.address.logic.commands.LaunchCommand.MESSAGE_MISSING_TELEGRAM;
 import static seedu.address.logic.commands.LaunchCommand.MESSAGE_UNRECOGNIZED_FLAG;

--- a/src/test/java/seedu/address/logic/parser/LaunchCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/LaunchCommandParserTest.java
@@ -3,7 +3,6 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_LAUNCH_APP_FLAG;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
-import static seedu.address.logic.parser.CliSyntax.FLAG_EMAIL_LAUNCH;
 import static seedu.address.logic.parser.CliSyntax.FLAG_GITHUB_LAUNCH;
 import static seedu.address.logic.parser.CliSyntax.FLAG_TELEGRAM_LAUNCH;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
@@ -41,10 +40,10 @@ public class LaunchCommandParserTest {
     @Test
     public void parse_invalidPreamble_failure() {
         // negative index
-        assertParseFailure(parser, "-5" + FLAG_EMAIL_LAUNCH, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "-5" + FLAG_TELEGRAM_LAUNCH, MESSAGE_INVALID_FORMAT);
 
         // zero index
-        assertParseFailure(parser, "0" + FLAG_EMAIL_LAUNCH, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "0" + FLAG_TELEGRAM_LAUNCH, MESSAGE_INVALID_FORMAT);
 
         // invalid arguments being parsed as preamble
         assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);
@@ -57,16 +56,6 @@ public class LaunchCommandParserTest {
     public void parse_invalidFlag_failure() {
         // invalid launch application flag
         assertParseFailure(parser, "1" + INVALID_LAUNCH_APP_FLAG, MESSAGE_INVALID_FORMAT);
-    }
-
-    /**
-     * Tests that parsing is successful when a valid Email launch flag is provided.
-     */
-    @Test
-    public void parse_validEmail_success() {
-        // valid email launch flag
-        LaunchCommand expectedCommand = new LaunchCommand(INDEX_FIRST_PERSON, ApplicationType.EMAIL);
-        assertParseSuccess(parser, "1 " + FLAG_EMAIL_LAUNCH, expectedCommand);
     }
 
     /**
@@ -94,21 +83,10 @@ public class LaunchCommandParserTest {
      */
     @Test
     public void parse_multipleFlags_failure() {
-        // email and telegram
-        assertParseFailure(
-                parser, "1 " + FLAG_EMAIL_LAUNCH + " " + FLAG_TELEGRAM_LAUNCH, MESSAGE_INVALID_FORMAT);
 
         // telegram and github
         assertParseFailure(
-                parser, "1 " + FLAG_EMAIL_LAUNCH + " " + FLAG_GITHUB_LAUNCH, MESSAGE_INVALID_FORMAT);
-
-        // email and github
-        assertParseFailure(
                 parser, "1 " + FLAG_TELEGRAM_LAUNCH + " " + FLAG_GITHUB_LAUNCH, MESSAGE_INVALID_FORMAT);
 
-        // all three flags
-        assertParseFailure(
-                parser, "1 " + FLAG_EMAIL_LAUNCH + " " + FLAG_TELEGRAM_LAUNCH + " " + FLAG_GITHUB_LAUNCH,
-                MESSAGE_INVALID_FORMAT);
     }
 }

--- a/src/test/java/seedu/address/logic/util/ApplicationLinkLauncherTest.java
+++ b/src/test/java/seedu/address/logic/util/ApplicationLinkLauncherTest.java
@@ -16,19 +16,6 @@ import org.mockito.MockedStatic;
 public class ApplicationLinkLauncherTest {
 
     @Test
-    void launchEmail_successfulLaunch_returnsSuccessResult() {
-        try (MockedStatic<DesktopApi> mockedDesktopApi = mockStatic(DesktopApi.class)) {
-            mockedDesktopApi.when(() -> DesktopApi.browse(any(URI.class))).thenReturn(true);
-
-            ApplicationLinkResult result = ApplicationLinkLauncher.launchEmail("test@example.com");
-
-            assertTrue(result.isSuccess());
-            assertTrue(result.getMessage().contains("Launched EMAIL successfully"));
-            mockedDesktopApi.verify(() -> DesktopApi.browse(any(URI.class)), times(1));
-        }
-    }
-
-    @Test
     void launchUserGuide_successfulLaunch_returnsSuccessResult() {
         try (MockedStatic<DesktopApi> mockedDesktopApi = mockStatic(DesktopApi.class)) {
             mockedDesktopApi.when(() -> DesktopApi.browse(any(URI.class))).thenReturn(true);
@@ -67,11 +54,6 @@ public class ApplicationLinkLauncherTest {
     }
 
     @Test
-    void launchEmail_nullEmail_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> ApplicationLinkLauncher.launchEmail(null));
-    }
-
-    @Test
     void launchTelegram_correctUriIsBuilt() throws URISyntaxException {
         try (MockedStatic<DesktopApi> mockedDesktopApi = mockStatic(DesktopApi.class)) {
             mockedDesktopApi.when(() -> DesktopApi.browse(any(URI.class))).thenReturn(true);
@@ -96,15 +78,15 @@ public class ApplicationLinkLauncherTest {
     }
 
     @Test
-    void launchEmail_desktopApiThrowsException_returnsFailureResult() {
+    void launchGitHub_desktopApiThrowsException_returnsFailureResult() {
         try (MockedStatic<DesktopApi> mockedDesktopApi = mockStatic(DesktopApi.class)) {
             mockedDesktopApi.when(() -> DesktopApi.browse(any(URI.class)))
                     .thenReturn(false); // simulate failure instead of throwing
 
-            ApplicationLinkResult result = ApplicationLinkLauncher.launchEmail("test@example.com");
+            ApplicationLinkResult result = ApplicationLinkLauncher.launchGithub("octocat");
 
             assertFalse(result.isSuccess());
-            assertTrue(result.getMessage().contains("Failed to launch EMAIL"));
+            assertTrue(result.getMessage().contains("Failed to launch GITHUB"));
         }
     }
 }

--- a/src/test/java/seedu/address/logic/util/ApplicationLinkLauncherTest.java
+++ b/src/test/java/seedu/address/logic/util/ApplicationLinkLauncherTest.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.util;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mockStatic;

--- a/src/test/java/seedu/address/logic/util/ApplicationLinkResultTest.java
+++ b/src/test/java/seedu/address/logic/util/ApplicationLinkResultTest.java
@@ -11,10 +11,10 @@ public class ApplicationLinkResultTest {
     @Test
     public void constructor_andGetters_workCorrectly() {
         ApplicationLinkResult successResult =
-                new ApplicationLinkResult(true, "Email opened successfully.");
+                new ApplicationLinkResult(true, "Telegram opened successfully.");
 
         assertTrue(successResult.isSuccess());
-        assertEquals("Email opened successfully.", successResult.getMessage());
+        assertEquals("Telegram opened successfully.", successResult.getMessage());
 
         ApplicationLinkResult failResult =
                 new ApplicationLinkResult(false, "Failed to open link.");


### PR DESCRIPTION
closes #270  
closes #273
closes  #281
closes  #288 

# Changes
Removed capability of launching email as I could not get it to work specifically through the web browser only. This is mainly because I wanted to be clearer in how we defined launching the application as a success as testers in PE-D seem to not understand the scope of the launch feature (mainly without internet access)

Hence, by isolating it such that users are ONLY allowed to launch via the web browser, I have made it **ABUNDANTLY** clear that they need to check the **URL** of the browser to deem if the feature has worked successfully or not. Hopefully this clarifies things for them whilst testing the application in the future.

I do foresee them flagging this as bug still in the future (mainly because they aren't able to verify if the link is actually correct with valid access to the internet)
- but to that I say, 
![bro-sounded-like-tuco-from-breaking-bad-tuco-get-out](https://github.com/user-attachments/assets/d61d38d5-3b6d-41c4-9e04-d191b47d4d89)
- Because, these links are trivial and common knowledge.
- Like who doesn't know github/telegram links
