### PR TITLE
Allow whitespace in confirm command

### DIFF
--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -162,7 +162,6 @@ public class LogicManager implements Logic {
      * An interface used for Storage saving operations.
      * This interface is used so that the IOExceptions can be thrown, as Java's
      * standard `Callable` does not allow for that.
-     *
      */
     @FunctionalInterface
     public interface Savable {

--- a/src/main/java/seedu/address/logic/commands/ConfirmCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ConfirmCommand.java
@@ -34,6 +34,9 @@ public class ConfirmCommand extends Command {
     public ConfirmCommand(String input,
                           Runnable onComplete,
                           ConfirmationPendingResult pendingOperation) {
+        requireNonNull(onComplete);
+        requireNonNull(pendingOperation);
+
         this.input = input.toLowerCase();
         this.pendingOperation = pendingOperation;
         this.onComplete = onComplete;

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -38,7 +38,7 @@ public class AddressBookParser {
     public Command parseConfirmationCommand(
             String userInput, Runnable onComplete, ConfirmationPendingResult pendingOp
     ) {
-        return new ConfirmCommand(userInput, onComplete, pendingOp);
+        return new ConfirmCommand(userInput.trim(), onComplete, pendingOp);
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/ConfirmCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ConfirmCommandTest.java
@@ -86,6 +86,20 @@ public class ConfirmCommandTest {
         assertCommandFailure(confirmCommand, model, expected);
     }
 
+    @Test
+    public void execute_confirmCommandYesWithCapitalization_performsOperation() {
+        Person personToDelete = model.getSortedAndFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        String expectedMessage = "Done!";
+        ConfirmCommand confirmCommand = createConfirmCommandWithDeletePending(
+            model, personToDelete, "YES", expectedMessage, "Delete user?"
+        );
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(), new CommandHistory());
+        expectedModel.deletePerson(personToDelete);
+
+        assertCommandSuccess(confirmCommand, model, "Done!", expectedModel);
+    }
+
 
     @Test
     public void toStringMethod() {


### PR DESCRIPTION
Closes #282 

Update to parser to trim user input when parsing to allow for trailing and preceding whitespace for Confirming Commands. 

(This should be a 4 LoC change, not including the tests)