### PR TITLE
Update parse name to remove extra spaces in name

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -50,10 +50,11 @@ public class ParserUtil {
     public static Name parseName(String name) throws ParseException {
         requireNonNull(name);
         String trimmedName = name.trim();
-        if (!Name.isValidName(trimmedName)) {
+        String nameWithoutAdditionalSpace = trimmedName.replaceAll("\\s+", " ");
+        if (!Name.isValidName(nameWithoutAdditionalSpace)) {
             throw new ParseException(Name.MESSAGE_CONSTRAINTS);
         }
-        return new Name(trimmedName);
+        return new Name(nameWithoutAdditionalSpace);
     }
 
     /**

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -31,6 +31,7 @@ public class ParserUtilTest {
     private static final String INVALID_PREFERRED_MODE = "none";
 
     private static final String VALID_NAME = "Rachel Walker";
+    private static final String VALID_NAME_WITH_ADDITIONAL_SPACES = "Rachel    Walker";
     private static final String VALID_PHONE = "123456";
     private static final String VALID_EMAIL = "rachel@example.com";
     private static final String VALID_PREFERRED_MODE_1 = "telegram";
@@ -82,6 +83,13 @@ public class ParserUtilTest {
     @Test
     public void parseName_validValueWithWhitespace_returnsTrimmedName() throws Exception {
         String nameWithWhitespace = WHITESPACE + VALID_NAME + WHITESPACE;
+        Name expectedName = new Name(VALID_NAME);
+        assertEquals(expectedName, ParserUtil.parseName(nameWithWhitespace));
+    }
+
+    @Test
+    public void parseName_validValueWithWhitespaceAndExtraSpaces_returnsTrimmedName() throws Exception {
+        String nameWithWhitespace = WHITESPACE + VALID_NAME_WITH_ADDITIONAL_SPACES + WHITESPACE;
         Name expectedName = new Name(VALID_NAME);
         assertEquals(expectedName, ParserUtil.parseName(nameWithWhitespace));
     }


### PR DESCRIPTION
close #243 

## Problem

`Bety Crown` is considered different to `Bety       Crown`. 

In real world, there should not be names with multiple spaces in between. It is likely that user adds another space by accident.

## Solution

Extra spaces in between are removed such that `Bety       Crown` will be formatted to `Bety Crown`. 