### PR TITLE
Add length validation for fields

### DIFF
--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -10,13 +10,15 @@ import java.util.Objects;
  */
 public class Email {
 
+    private static final int MAX_LENGTH = 254;
     private static final String SPECIAL_CHARACTERS = "+_.-";
     public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format local-part@domain "
             + "and adhere to the following constraints:\n"
-            + "1. The local-part should only contain alphanumeric characters and these special characters, excluding "
+            + "1. Email length should not exceed " + MAX_LENGTH + " characters.\n"
+            + "2. The local-part should only contain alphanumeric characters and these special characters, excluding "
             + "the parentheses, (" + SPECIAL_CHARACTERS + "). The local-part may not start or end with any special "
             + "characters.\n"
-            + "2. This is followed by a '@' and then a domain name. The domain name is made up of domain labels "
+            + "3. This is followed by a '@' and then a domain name. The domain name is made up of domain labels "
             + "separated by periods.\n"
             + "The domain name must:\n"
             + "    - end with a domain label at least 2 characters long\n"
@@ -60,7 +62,8 @@ public class Email {
             return true;
         }
 
-        return test.matches(VALIDATION_REGEX);
+        boolean isEmailValid = test.matches(VALIDATION_REGEX) && test.length() <= MAX_LENGTH;
+        return isEmailValid;
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -11,8 +11,9 @@ public class Phone {
 
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Phone numbers should only contain numbers, and it should be at least 3 digits long";
-    public static final String VALIDATION_REGEX = "\\d{3,}";
+            "Phone numbers should only contain numbers, "
+                    + "and it should be be between 3 and 17 digits long";
+    public static final String VALIDATION_REGEX = "\\d{3,17}";
     public final String value;
 
     /**

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -9,8 +9,9 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Tag {
 
-    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric";
-    public static final String VALIDATION_REGEX = "\\p{Alnum}+";
+    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric "
+            + "and should not be longer than 128 characters.";
+    public static final String VALIDATION_REGEX = "\\p{Alnum}{1,128}";
 
     public final String tagName;
 

--- a/src/test/java/seedu/address/model/person/EmailTest.java
+++ b/src/test/java/seedu/address/model/person/EmailTest.java
@@ -45,6 +45,12 @@ public class EmailTest {
         assertFalse(Email.isValidEmail("peterjack@-example.com")); // domain name starts with a hyphen
         assertFalse(Email.isValidEmail("peterjack@example.com-")); // domain name ends with a hyphen
         assertFalse(Email.isValidEmail("peterjack@example.c")); // top level domain has less than two chars
+        // length exceeds 254 characters
+        assertFalse(Email.isValidEmail(
+                "A".repeat(64)
+                        + "@"
+                        + "B".repeat(186)
+                        + ".com"));
 
         // valid email
         assertTrue(Email.isValidEmail(null)); // empty email
@@ -59,6 +65,12 @@ public class EmailTest {
         assertTrue(Email.isValidEmail("peter_jack@very-very-very-long-example.com")); // long domain name
         assertTrue(Email.isValidEmail("if.you.dream.it_you.can.do.it@example.com")); // long local part
         assertTrue(Email.isValidEmail("e1234567@u.nus.edu")); // more than one period in domain
+        // Length 254 characters, within max length of 254 characters
+        assertTrue(Email.isValidEmail(
+                "A".repeat(64)
+                        + "@"
+                        + "B".repeat(185)
+                        + ".com"));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/PhoneTest.java
+++ b/src/test/java/seedu/address/model/person/PhoneTest.java
@@ -31,11 +31,12 @@ public class PhoneTest {
         assertFalse(Phone.isValidPhone("phone")); // non-numeric
         assertFalse(Phone.isValidPhone("9011p041")); // alphabets within digits
         assertFalse(Phone.isValidPhone("9312 1534")); // spaces within digits
+        assertFalse(Phone.isValidPhone("124293842033123670")); // more than 17 numbers
 
         // valid phone numbers
         assertTrue(Phone.isValidPhone("911")); // exactly 3 numbers
         assertTrue(Phone.isValidPhone("93121534"));
-        assertTrue(Phone.isValidPhone("124293842033123")); // long phone numbers
+        assertTrue(Phone.isValidPhone("12429384203312367")); // long phone number, exactly 17 numbers
     }
 
     @Test

--- a/src/test/java/seedu/address/model/tag/TagTest.java
+++ b/src/test/java/seedu/address/model/tag/TagTest.java
@@ -1,5 +1,7 @@
 package seedu.address.model.tag;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -21,6 +23,24 @@ public class TagTest {
     public void isValidTagName() {
         // null tag name
         assertThrows(NullPointerException.class, () -> Tag.isValidTagName(null));
+
+        // invalid tag names
+        assertFalse(Tag.isValidTagName(""));
+        assertFalse(Tag.isValidTagName("tag-name"));
+        assertFalse(Tag.isValidTagName("tag_name"));
+        assertFalse(Tag.isValidTagName("tag name"));
+        assertFalse(Tag.isValidTagName("tag@name"));
+        assertFalse(Tag.isValidTagName("tag.name"));
+        assertFalse(Tag.isValidTagName("tag#name"));
+        assertFalse(Tag.isValidTagName("tag!"));
+        assertFalse(Tag.isValidTagName("A".repeat(129))); // boundary case
+
+        // valid tag names
+        assertTrue(Tag.isValidTagName("tag"));
+        assertTrue(Tag.isValidTagName("MyNewTag"));
+        assertTrue(Tag.isValidTagName("tag123"));
+        assertTrue(Tag.isValidTagName("TAG"));
+        assertTrue(Tag.isValidTagName("A".repeat(128))); // boundary case
     }
 
 }


### PR DESCRIPTION
close #298 
close #293 

## Changes

Phone, tag, and email length are validated. 

Phone length should now be between 3 to 17 digits, based on the shortest and longest phone number length in real world

Email address length should be shorter than 255 characters, based on erratum [1690](https://www.rfc-editor.org/errata/eid1690)

Tag length should be shorter than 128 characters, this should be ample for users while not breaking the UI